### PR TITLE
cmake: update the minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 # XXX using 1.8.90 instead of 1.9.0-DEV
 project(nghttp2 VERSION 1.52.0)
 


### PR DESCRIPTION
For CMake 4.0, compatibility with versions of CMake older than 3.5 has been removed [1]. Thus, on macOS it leads to the error on build, since Homebrew updates it to version 4.0.

This patch sets the minimum required version to 3.5 for now.

[1]: https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features